### PR TITLE
Replace text/template for a significant log speedup

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -5,7 +5,6 @@
 package log
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -143,20 +142,15 @@ func (l Logger) log(cmd, message string, annotations ...Annotation) {
 		annotation.apply(&ann)
 	}
 
-	buf := &bytes.Buffer{}
-	if err := templ.Execute(buf, ann); err != nil {
-		// I guess just return the unannotated message?
-		fmt.Fprintf(l.out, "::%s::%s\n", cmd, message)
-		return
-	}
+	annotation := ann.String()
 
-	// If there were no annotations after rendering the template (due to the rules for the annotations)
-	// then we can just do the message again
-	if buf.Len() == 0 {
+	// If there were no annotations after stringifying it (due to the rules for the annotations)
+	// then we can just do the raw message again
+	if len(annotation) == 0 {
 		fmt.Fprintf(l.out, "::%s::%s\n", cmd, message)
 		return
 	}
 
 	// Otherwise we need a space after ::<cmd> and the first annotation
-	fmt.Fprintf(l.out, "::%s %s::%s\n", cmd, buf.String(), message)
+	fmt.Fprintf(l.out, "::%s %s::%s\n", cmd, annotation, message)
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -2,6 +2,7 @@ package log_test
 
 import (
 	"bytes"
+	"io"
 	"testing"
 
 	"github.com/FollowTheProcess/actions/log"
@@ -326,4 +327,13 @@ func TestError(t *testing.T) {
 	got := buf.String()
 	want := "::error title=Syntax Error,file=src/main.py,line=2,endLine=6::This is broken\n"
 	test.Diff(t, got, want)
+}
+
+func BenchmarkLog(b *testing.B) {
+	logger := log.New(io.Discard)
+
+	b.ResetTimer()
+	for range b.N {
+		logger.Notice("Hello", log.Title("A Title"), log.File("src/main.rs"), log.Lines(1, 18))
+	}
 }


### PR DESCRIPTION
# Summary

<!-- Describe your changes in detail here, if it closes an open issue, include "Closes #<issue>" -->
Replaces `text/template` with a simple `strings.Builder` for a pretty dramatic performance improvement:

```plaintext
goos: darwin
goarch: arm64
pkg: github.com/FollowTheProcess/actions/log
cpu: Apple M1 Pro
      │  before.txt  │              after.txt              │
      │    sec/op    │   sec/op     vs base                │
Log-8   6066.5n ± 0%   357.2n ± 0%  -94.11% (p=0.000 n=30)

      │ before.txt  │             after.txt              │
      │    B/op     │    B/op     vs base                │
Log-8   2216.0 ± 0%   320.0 ± 0%  -85.56% (p=0.000 n=30)

      │ before.txt │             after.txt              │
      │ allocs/op  │ allocs/op   vs base                │
Log-8   87.00 ± 0%   13.00 ± 0%  -85.06% (p=0.000 n=30)
```
